### PR TITLE
Add support for Web App buttons

### DIFF
--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -1,2 +1,2 @@
 export * from "https://lib.deno.dev/x/grammy@1.x/mod.ts";
-export * from "https://cdn.skypack.dev/@grammyjs/types@v2?dts";
+export * from "https://esm.sh/@grammyjs/types@v2";

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -275,22 +275,6 @@ export class MenuRange<C extends Context> {
         return this.add({ text, url });
     }
     /**
-     * Adds a new login button. This can be used as a replacement for the
-     * Telegram Login Widget. You must specify an HTTP URL used to automatically
-     * authorize the user.
-     *
-     * @param text The text to display
-     * @param loginUrl The login URL as string or `LoginUrl` object
-     */
-    login(text: MaybeDynamicString<C>, loginUrl: string | LoginUrl) {
-        return this.add({
-            text,
-            login_url: typeof loginUrl === "string"
-                ? { url: loginUrl }
-                : loginUrl,
-        });
-    }
-    /**
      * Adds a new text button. You may pass any number of listeners. They will
      * be called when the button is pressed.
      *
@@ -346,6 +330,32 @@ export class MenuRange<C extends Context> {
                 ? { ...text, middleware }
                 : { text, middleware },
         );
+    }
+    /**
+     * Adds a new web app button, confer https://core.telegram.org/bots/webapps
+     *
+     * @param text The text to display
+     * @param url An HTTPS URL of a Web App to be opened with additional data
+     */
+
+    webApp(text: string, url: string) {
+        return this.add({ text, web_app: { url } });
+    }
+    /**
+     * Adds a new login button. This can be used as a replacement for the
+     * Telegram Login Widget. You must specify an HTTP URL used to automatically
+     * authorize the user.
+     *
+     * @param text The text to display
+     * @param loginUrl The login URL as string or `LoginUrl` object
+     */
+    login(text: MaybeDynamicString<C>, loginUrl: string | LoginUrl) {
+        return this.add({
+            text,
+            login_url: typeof loginUrl === "string"
+                ? { url: loginUrl }
+                : loginUrl,
+        });
     }
     /**
      * Adds a new inline query button. Telegram clients will let the user pick a


### PR DESCRIPTION
This updates the plugin to Bot API 6.0.

For some reason, skypack fails to build the new type dependency. I cannot figure out why. Using https://esm.sh now.
