### PR TITLE
Fix esm.sh to download newest @grammyjs/types

### DIFF
--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -1,2 +1,2 @@
 export * from "https://lib.deno.dev/x/grammy@1.x/mod.ts";
-export * from "https://esm.sh/@grammyjs/types@v2";
+export * from "https://esm.sh/@grammyjs/types@2";


### PR DESCRIPTION
https://esm.sh/@grammyjs/types@v2 redirects to 2.0.0 
https://esm.sh/@grammyjs/types@2 redirects to newest 2.12.1

Because of this issue I constantly receive error "Deno has panicked. thread 'main' panicked at 'internal error: entered unreachable code'"