### PR TITLE
Change to allow url to be a dynamic string

### DIFF
--- a/src/menu.ts
+++ b/src/menu.ts
@@ -270,7 +270,7 @@ export class MenuRange<C extends Context> {
      * @param text The text to display
      * @param url HTTP or tg:// url to be opened when button is pressed. Links tg://user?id=<user_id> can be used to mention a user by their ID without using a username, if this is allowed by their privacy settings.
      */
-    url(text: MaybeDynamicString<C>, url: string) {
+    url(text: MaybeDynamicString<C>, url: MaybeDynamicString<C>) {
         return this.add({ text, url });
     }
     /**
@@ -787,6 +787,13 @@ export class Menu<C extends Context = Context> extends MenuRange<C>
             ctx,
             async (btn, i, j): Promise<InlineKeyboardButton> => {
                 const text = await uniform(ctx, btn.text);
+                
+                if ("url" in btn) {
+                    let {url, ...rest} = btn;
+                    url = await uniform(ctx, btn.url);
+                    return { ...rest, url, text };
+                }
+                
                 if ("middleware" in btn) {
                     const row = i.toString(16);
                     const col = j.toString(16);

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -792,9 +792,7 @@ export class Menu<C extends Context = Context> extends MenuRange<C>
                     let {url, ...rest} = btn;
                     url = await uniform(ctx, btn.url);
                     return { ...rest, url, text };
-                }
-                
-                if ("middleware" in btn) {
+                } else if ("middleware" in btn) {
                     const row = i.toString(16);
                     const col = j.toString(16);
                     const payload = await uniform(ctx, btn.payload, "");


### PR DESCRIPTION
Allow url in menu to be dynamic, this allows for things like having a menu to buy items, and having url button that allows user to visit the link/url to see the item

I was facing the issue of not being able to dynamically construct url to use in menu and do not want to create a new unique menu for all my different items, seeing that text is able to be dynamically constructed, urls should be as well