### PR TITLE
Annotate Menu#middleware return type to avoid deep grammy import (closes #49)

### DIFF
--- a/src/menu.ts
+++ b/src/menu.ts
@@ -7,6 +7,7 @@ import {
     type InlineKeyboardMarkup,
     type LoginUrl,
     type Middleware,
+    type MiddlewareFn,
     type MiddlewareObj,
     type SwitchInlineQueryChosenChat,
 } from "./deps.deno.ts";
@@ -1014,7 +1015,7 @@ export class Menu<C extends Context = Context> extends MenuRange<C>
             }
         }
     }
-    middleware() {
+    middleware(): MiddlewareFn<C> {
         const composer = new Composer<C>((ctx, next) => {
             ctx.api.config.use(async (prev, method, payload, signal) => {
                 const p: Record<string, unknown> = payload;


### PR DESCRIPTION
Closes #49.

### Root cause

`Menu#middleware` had no explicit return type. The declaration emitter inferred the type as `MiddlewareFn<C>` but wrote it using grammy's internal path, producing this in the generated `out/menu.d.ts`:

```ts
middleware(): import("grammy/out/composer.js").MiddlewareFn<C>;
```

grammy's `package.json` only exposes `.`, `./types`, and `./web` via `exports`. Under TypeScript's `node16`/`nodenext` module resolution (which respects `exports`), the deep path `grammy/out/composer.js` is unresolvable, so consumers of `@grammyjs/menu` hit `TS2307 Cannot find module 'grammy/out/composer.js'` at build time. The maintainer's `skipLibCheck` suggestion in the issue works around it but masks other problems too.

### Fix

1. Import `MiddlewareFn` via `./deps.deno.ts` (which re-exports from grammy through its public entry).
2. Annotate `middleware(): MiddlewareFn<C>` explicitly.

With the annotation, the declaration emitter writes the type against the import that was used in the source, so the generated `out/menu.d.ts` now emits:

```ts
import { ..., type MiddlewareFn, ... } from "./deps.node.js";
...
middleware(): MiddlewareFn<C>;
```

No more deep path, no more TS2307.

### Verified

- `npm install && npm run build` produces a clean `out/menu.d.ts` where the only mention of `MiddlewareFn` is through the `./deps.node.js` import. No `grammy/out/composer.js` references remain anywhere in the declaration output.
- Diff is two lines: one added import, one return type annotation. No behavior change.